### PR TITLE
feat: nudge agent — long-lived agent sessions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Subscription system for AI agents — wait for events, get nudged when they happen"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 rusqlite = { version = "0.31", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,0 +1,414 @@
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use tokio::io::AsyncBufReadExt;
+use tokio::process::Command;
+
+use crate::cli::AgentArgs;
+use crate::store::Store;
+use crate::subscription::Subscription;
+
+/// Manages state for running Claude Code CLI turns via `--resume`.
+struct AgentRunner {
+    /// Claude Code session ID, captured from the first turn's init message.
+    session_id: Option<String>,
+    /// Unique identifier for this agent instance (short UUID).
+    agent_id: String,
+    /// If set, run an idle turn after this duration of inactivity.
+    idle_every: Option<Duration>,
+    /// Prompt content to use for idle turns.
+    idle_prompt: Option<String>,
+    /// Maximum wall-clock time for a single Claude Code turn.
+    turn_timeout: Duration,
+    /// Timestamp of the last completed turn.
+    last_turn_at: Option<Instant>,
+    /// Tracks consecutive turns that completed within 10s (for backoff).
+    consecutive_fast_turns: u32,
+}
+
+/// Run a single Claude Code CLI turn with the given prompt.
+///
+/// Builds and spawns: `claude -p --output-format stream-json [--resume <id>] "<prompt>"`
+/// Parses NDJSON stdout to capture the session ID on init and detect turn completion.
+/// Applies `turn_timeout` — kills the child process if exceeded.
+async fn run_claude_turn(runner: &mut AgentRunner, prompt: &str) -> Result<()> {
+    let mut cmd = Command::new("claude");
+    cmd.arg("-p")
+        .arg("--output-format")
+        .arg("stream-json");
+
+    if let Some(ref session_id) = runner.session_id {
+        cmd.arg("--resume").arg(session_id);
+    }
+
+    cmd.arg(prompt);
+
+    cmd.env("NUDGE_AGENT_ID", &runner.agent_id);
+
+    cmd.stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::inherit())
+        .stdin(std::process::Stdio::null());
+
+    tracing::info!(
+        agent_id = %runner.agent_id,
+        has_session = runner.session_id.is_some(),
+        "Starting Claude Code turn"
+    );
+
+    let mut child = cmd.spawn().map_err(|e| {
+        anyhow::anyhow!("Failed to spawn claude CLI: {e}. Is `claude` on PATH?")
+    })?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("Failed to capture claude stdout"))?;
+
+    let reader = tokio::io::BufReader::new(stdout);
+    let mut lines = reader.lines();
+
+    let process_lines = async {
+        while let Some(line) = lines.next_line().await? {
+            // Try to parse as JSON to extract session_id and detect completion
+            if let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) {
+                // Check for init message: {"type":"system","subtype":"init","session_id":"..."}
+                if value.get("type").and_then(|v| v.as_str()) == Some("system")
+                    && value.get("subtype").and_then(|v| v.as_str()) == Some("init")
+                {
+                    if let Some(sid) = value.get("session_id").and_then(|v| v.as_str()) {
+                        tracing::info!(session_id = %sid, "Captured session ID");
+                        runner.session_id = Some(sid.to_string());
+                    }
+                    continue;
+                }
+
+                // Check for result message: {"type":"result",...}
+                if value.get("type").and_then(|v| v.as_str()) == Some("result") {
+                    tracing::debug!("Turn completed (result message received)");
+                    break;
+                }
+            }
+
+            // Log all other lines for debugging
+            eprintln!("[claude] {line}");
+        }
+        Ok::<(), anyhow::Error>(())
+    };
+
+    // Apply turn timeout
+    match tokio::time::timeout(runner.turn_timeout, process_lines).await {
+        Ok(result) => result?,
+        Err(_) => {
+            tracing::warn!(
+                timeout_secs = runner.turn_timeout.as_secs(),
+                "Turn timed out, killing child process"
+            );
+            let _ = child.kill().await;
+            anyhow::bail!(
+                "Claude Code turn timed out after {}s",
+                runner.turn_timeout.as_secs()
+            );
+        }
+    }
+
+    // Wait for the child process to exit
+    let _ = child.wait().await;
+
+    runner.last_turn_at = Some(Instant::now());
+
+    tracing::info!(agent_id = %runner.agent_id, "Turn finished");
+    Ok(())
+}
+
+/// Format fired subscriptions into a prompt for Claude Code.
+///
+/// Produces a numbered list like:
+/// ```text
+/// Events received:
+/// 1. foo/bar pr #42 merged -- Memo: Check if tests pass
+/// 2. timer 5m
+/// ```
+fn format_events_with_memos(subs: &[Subscription]) -> String {
+    let mut lines = vec!["Events received:".to_string()];
+    for (i, sub) in subs.iter().enumerate() {
+        let summary = sub.condition_summary();
+        let line = if let Some(ref memo) = sub.memo {
+            format!("{}. {} -- Memo: {}", i + 1, summary, memo)
+        } else {
+            format!("{}. {}", i + 1, summary)
+        };
+        lines.push(line);
+    }
+    lines.join("\n")
+}
+
+/// Check whether enough idle time has elapsed to trigger an idle turn.
+fn should_idle(runner: &AgentRunner) -> bool {
+    let idle_every = match runner.idle_every {
+        Some(d) => d,
+        None => return false,
+    };
+
+    // No idle prompt configured means we can't run idle turns
+    if runner.idle_prompt.is_none() {
+        return false;
+    }
+
+    match runner.last_turn_at {
+        Some(last) => last.elapsed() >= idle_every,
+        // Never ran a turn yet -- idle after the interval from start
+        None => true,
+    }
+}
+
+/// Per-session rate limiter.
+///
+/// Consecutive turns completing within 10s trigger exponential backoff:
+/// 10s -> 20s -> 40s -> 80s -> 160s -> 300s (capped).
+async fn rate_limit_check(runner: &mut AgentRunner) {
+    if let Some(last) = runner.last_turn_at {
+        let elapsed = last.elapsed();
+        if elapsed < Duration::from_secs(10) {
+            runner.consecutive_fast_turns += 1;
+            let backoff = Duration::from_secs(
+                (10 * 2u64.pow(runner.consecutive_fast_turns.min(5))).min(300),
+            );
+            tracing::warn!(
+                backoff_secs = backoff.as_secs(),
+                consecutive = runner.consecutive_fast_turns,
+                "Rate limiting: backing off"
+            );
+            tokio::time::sleep(backoff).await;
+        } else {
+            runner.consecutive_fast_turns = 0;
+        }
+    }
+}
+
+/// Parse a duration string (e.g., "30s", "5m", "2h") into a `std::time::Duration`.
+fn parse_std_duration(s: &str) -> Result<Duration> {
+    let secs = crate::subscription::parse_duration_secs(s)?;
+    Ok(Duration::from_secs(secs as u64))
+}
+
+/// Entry point for the `nudge agent` command.
+///
+/// Runs an event-driven agent loop that:
+/// 1. Polls the subscription store for fired events targeting this agent
+/// 2. Formats events (with optional memos) into prompts
+/// 3. Sends prompts to Claude Code CLI, maintaining session context via `--resume`
+/// 4. Optionally runs idle turns when no events have arrived for a configurable period
+pub async fn run(args: AgentArgs) -> Result<()> {
+    // 1. Generate a short agent ID
+    let agent_id = uuid::Uuid::new_v4().to_string()[..8].to_string();
+
+    // 2. Parse --idle-every duration
+    let idle_every = args
+        .idle_every
+        .as_deref()
+        .map(parse_std_duration)
+        .transpose()?;
+
+    // 3. Read --idle-prompt-file content
+    let idle_prompt = match args.idle_prompt_file {
+        Some(ref path) => {
+            let content = std::fs::read_to_string(path).map_err(|e| {
+                anyhow::anyhow!("Failed to read idle prompt file {}: {e}", path.display())
+            })?;
+            Some(content)
+        }
+        None => None,
+    };
+
+    // 4. Parse --turn-timeout (default is "600s" from CLI)
+    let turn_timeout = parse_std_duration(args.turn_timeout.as_deref().unwrap_or("600s"))?;
+
+    // 5. Ensure the daemon is running (it processes subscriptions)
+    crate::daemon::ensure_running()?;
+
+    tracing::info!(
+        agent_id = %agent_id,
+        idle_every_secs = idle_every.map(|d| d.as_secs()),
+        turn_timeout_secs = turn_timeout.as_secs(),
+        "Agent starting"
+    );
+
+    let mut runner = AgentRunner {
+        session_id: None,
+        agent_id: agent_id.clone(),
+        idle_every,
+        idle_prompt,
+        turn_timeout,
+        last_turn_at: None,
+        consecutive_fast_turns: 0,
+    };
+
+    // Main loop: poll for events, run Claude turns, handle idle
+    loop {
+        let db = Store::open_default()?;
+
+        // Check for fired events targeting this agent
+        let events = db.list_fired_for_agent(&agent_id)?;
+
+        if !events.is_empty() {
+            // Mark events as dispatched so they aren't re-processed
+            let ids: Vec<String> = events.iter().map(|e| e.id.clone()).collect();
+            db.mark_dispatched(&ids)?;
+
+            let prompt = format_events_with_memos(&events);
+            drop(db);
+
+            tracing::info!(
+                event_count = events.len(),
+                "Dispatching {} event(s) to Claude",
+                events.len()
+            );
+
+            rate_limit_check(&mut runner).await;
+            run_claude_turn(&mut runner, &prompt).await?;
+        } else if should_idle(&runner) {
+            // Run an idle turn
+            if let Some(ref prompt) = runner.idle_prompt {
+                let prompt = prompt.clone();
+                drop(db);
+
+                tracing::info!("Running idle turn");
+
+                rate_limit_check(&mut runner).await;
+                run_claude_turn(&mut runner, &prompt).await?;
+            } else {
+                drop(db);
+                tokio::time::sleep(Duration::from_secs(2)).await;
+            }
+        } else {
+            drop(db);
+            // No events and not idle-due -- sleep before next poll
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::subscription::{Condition, Subscription};
+
+    fn make_sub(id: &str, memo: Option<&str>) -> Subscription {
+        Subscription {
+            id: id.into(),
+            source: "timer".into(),
+            condition: Condition::Timer {
+                duration: "5m".into(),
+                fire_at: 0,
+            },
+            mode: "wait".into(),
+            callback: None,
+            status: "fired".into(),
+            created_at: 0,
+            expires_at: None,
+            event_data: None,
+            memo: memo.map(|s| s.to_string()),
+            agent_id: None,
+        }
+    }
+
+    #[test]
+    fn test_format_events_single_no_memo() {
+        let subs = vec![make_sub("a", None)];
+        let result = format_events_with_memos(&subs);
+        assert_eq!(result, "Events received:\n1. timer 5m");
+    }
+
+    #[test]
+    fn test_format_events_single_with_memo() {
+        let subs = vec![make_sub("a", Some("Check CI status"))];
+        let result = format_events_with_memos(&subs);
+        assert_eq!(
+            result,
+            "Events received:\n1. timer 5m -- Memo: Check CI status"
+        );
+    }
+
+    #[test]
+    fn test_format_events_multiple_mixed() {
+        let subs = vec![
+            make_sub("a", Some("First memo")),
+            make_sub("b", None),
+            make_sub("c", Some("Third memo")),
+        ];
+        let result = format_events_with_memos(&subs);
+        let expected = "Events received:\n\
+                        1. timer 5m -- Memo: First memo\n\
+                        2. timer 5m\n\
+                        3. timer 5m -- Memo: Third memo";
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_should_idle_no_config() {
+        let runner = AgentRunner {
+            session_id: None,
+            agent_id: "test".into(),
+            idle_every: None,
+            idle_prompt: None,
+            turn_timeout: Duration::from_secs(600),
+            last_turn_at: None,
+            consecutive_fast_turns: 0,
+        };
+        assert!(!should_idle(&runner));
+    }
+
+    #[test]
+    fn test_should_idle_no_prompt() {
+        let runner = AgentRunner {
+            session_id: None,
+            agent_id: "test".into(),
+            idle_every: Some(Duration::from_secs(60)),
+            idle_prompt: None,
+            turn_timeout: Duration::from_secs(600),
+            last_turn_at: None,
+            consecutive_fast_turns: 0,
+        };
+        assert!(!should_idle(&runner));
+    }
+
+    #[test]
+    fn test_should_idle_never_ran() {
+        let runner = AgentRunner {
+            session_id: None,
+            agent_id: "test".into(),
+            idle_every: Some(Duration::from_secs(60)),
+            idle_prompt: Some("check in".into()),
+            turn_timeout: Duration::from_secs(600),
+            last_turn_at: None,
+            consecutive_fast_turns: 0,
+        };
+        // First idle should fire immediately since no turn has ever run
+        assert!(should_idle(&runner));
+    }
+
+    #[test]
+    fn test_should_idle_recently_ran() {
+        let runner = AgentRunner {
+            session_id: None,
+            agent_id: "test".into(),
+            idle_every: Some(Duration::from_secs(300)),
+            idle_prompt: Some("check in".into()),
+            turn_timeout: Duration::from_secs(600),
+            last_turn_at: Some(Instant::now()),
+            consecutive_fast_turns: 0,
+        };
+        // Just ran, should not idle yet
+        assert!(!should_idle(&runner));
+    }
+
+    #[test]
+    fn test_parse_std_duration() {
+        assert_eq!(parse_std_duration("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_std_duration("5m").unwrap(), Duration::from_secs(300));
+        assert_eq!(
+            parse_std_duration("2h").unwrap(),
+            Duration::from_secs(7200)
+        );
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use clap::{Parser, Subcommand, Args};
 
 #[derive(Parser)]
@@ -24,6 +25,8 @@ pub enum Command {
     Status,
     /// Start the daemon (usually auto-started)
     Daemon(DaemonArgs),
+    /// Run as a long-lived agent with idle-turn scheduling
+    Agent(AgentArgs),
 }
 
 #[derive(Args)]
@@ -38,6 +41,15 @@ pub struct WaitArgs {
     /// GitHub repo (owner/repo)
     #[arg(long)]
     pub repo: Option<String>,
+    /// Register subscription and return immediately (don't block)
+    #[arg(long)]
+    pub detach: bool,
+    /// Note for what to do when event fires
+    #[arg(long)]
+    pub memo: Option<String>,
+    /// Agent ID (set automatically via NUDGE_AGENT_ID env var)
+    #[arg(long, env = "NUDGE_AGENT_ID", hide = true)]
+    pub agent_id: Option<String>,
 }
 
 #[derive(Args)]
@@ -75,4 +87,17 @@ pub struct DaemonArgs {
     /// Webhook listen port
     #[arg(long, default_value = "9876")]
     pub webhook_port: u16,
+}
+
+#[derive(Args)]
+pub struct AgentArgs {
+    /// Interval for idle-turn checks (e.g., "4h", "30m")
+    #[arg(long)]
+    pub idle_every: Option<String>,
+    /// File containing the idle-turn prompt
+    #[arg(long)]
+    pub idle_prompt_file: Option<PathBuf>,
+    /// Maximum duration for a single turn (default: 600s)
+    #[arg(long, default_value = "600s")]
+    pub turn_timeout: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod agent;
 mod cli;
 mod store;
 mod checker;
@@ -26,10 +27,12 @@ async fn main() -> Result<()> {
         Command::Cancel { id } => cmd_cancel(&id).await,
         Command::Status => cmd_status().await,
         Command::Daemon(args) => cmd_daemon(args).await,
+        Command::Agent(args) => agent::run(args).await,
     }
 }
 
 async fn cmd_wait(args: cli::WaitArgs) -> Result<()> {
+    let detach = args.detach;
     let sub = subscription::Subscription::from_wait_args(&args)?;
 
     // Ensure daemon is running BEFORE inserting — avoids orphan subscriptions if daemon fails
@@ -37,6 +40,18 @@ async fn cmd_wait(args: cli::WaitArgs) -> Result<()> {
 
     let db = store::Store::open_default()?;
     let id = db.insert(&sub)?;
+
+    if detach {
+        // Print hint and exit — the agent loop will pick up the fired event later
+        let summary = sub.condition_summary();
+        println!("Watching {summary} in background.");
+        if let Some(ref memo) = sub.memo {
+            println!("Memo: {memo}");
+        }
+        println!("You can end this turn. A new turn will start when the event fires.");
+        return Ok(());
+    }
+
     tracing::info!(id = %id, source = %sub.source, "Watching...");
 
     // Block until fired or timeout

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -33,6 +33,20 @@ impl Store {
             CREATE INDEX IF NOT EXISTS idx_sub_status ON subscriptions(status);
             CREATE INDEX IF NOT EXISTS idx_sub_source ON subscriptions(source);",
         )?;
+
+        // Schema migrations: add new columns (ignore "duplicate column" errors)
+        for col in ["memo TEXT", "agent_id TEXT", "dispatched_at INTEGER"] {
+            let sql = format!("ALTER TABLE subscriptions ADD COLUMN {col}");
+            match conn.execute(&sql, []) {
+                Ok(_) => {}
+                Err(e) if e.to_string().contains("duplicate column") => {}
+                Err(e) => return Err(e.into()),
+            }
+        }
+        conn.execute_batch(
+            "CREATE INDEX IF NOT EXISTS idx_sub_agent_id ON subscriptions(agent_id);",
+        )?;
+
         Ok(Self { conn })
     }
 
@@ -52,8 +66,8 @@ impl Store {
 
     pub fn insert(&self, sub: &Subscription) -> Result<String> {
         self.conn.execute(
-            "INSERT INTO subscriptions (id, source, condition, mode, callback, status, created_at, expires_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            "INSERT INTO subscriptions (id, source, condition, mode, callback, status, created_at, expires_at, memo, agent_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             params![
                 sub.id,
                 sub.source,
@@ -63,6 +77,8 @@ impl Store {
                 sub.status,
                 sub.created_at,
                 sub.expires_at,
+                sub.memo,
+                sub.agent_id,
             ],
         )?;
         Ok(sub.id.clone())
@@ -70,7 +86,7 @@ impl Store {
 
     pub fn get(&self, id: &str) -> Result<Option<Subscription>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, source, condition, mode, callback, status, created_at, expires_at, event_data
+            "SELECT id, source, condition, mode, callback, status, created_at, expires_at, event_data, memo, agent_id
              FROM subscriptions WHERE id = ?1",
         )?;
         let mut rows = stmt.query_map(params![id], |row| {
@@ -89,7 +105,7 @@ impl Store {
     }
 
     pub fn list(&self, source: Option<&str>, status: Option<&str>) -> Result<Vec<Subscription>> {
-        let mut sql = "SELECT id, source, condition, mode, callback, status, created_at, expires_at, event_data FROM subscriptions WHERE 1=1".to_string();
+        let mut sql = "SELECT id, source, condition, mode, callback, status, created_at, expires_at, event_data, memo, agent_id FROM subscriptions WHERE 1=1".to_string();
         let mut values: Vec<Box<dyn rusqlite::types::ToSql>> = vec![];
 
         if let Some(s) = source {
@@ -173,6 +189,43 @@ impl Store {
         }
         Ok(counts)
     }
+
+    pub fn list_fired_for_agent(&self, agent_id: &str) -> Result<Vec<Subscription>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, source, condition, mode, callback, status, created_at, expires_at, event_data, memo, agent_id
+             FROM subscriptions
+             WHERE agent_id = ?1 AND status = 'fired' AND dispatched_at IS NULL
+             ORDER BY created_at ASC",
+        )?;
+        let rows = stmt.query_map(params![agent_id], |row| Ok(row_to_sub(row)))?;
+        let mut subs = vec![];
+        for row in rows {
+            if let Some(sub) = row? {
+                subs.push(sub);
+            }
+        }
+        Ok(subs)
+    }
+
+    pub fn mark_dispatched(&self, ids: &[String]) -> Result<()> {
+        let now = chrono::Utc::now().timestamp();
+        for id in ids {
+            self.conn.execute(
+                "UPDATE subscriptions SET dispatched_at = ?1 WHERE id = ?2",
+                params![now, id],
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn has_active_subscriptions(&self, agent_id: &str) -> Result<bool> {
+        let has: bool = self.conn.query_row(
+            "SELECT COUNT(*) > 0 FROM subscriptions WHERE agent_id = ?1 AND status = 'active'",
+            params![agent_id],
+            |row| row.get(0),
+        )?;
+        Ok(has)
+    }
 }
 
 fn row_to_sub(row: &rusqlite::Row) -> Option<Subscription> {
@@ -198,6 +251,8 @@ fn row_to_sub(row: &rusqlite::Row) -> Option<Subscription> {
         created_at: row.get(6).unwrap_or(0),
         expires_at: row.get(7).unwrap_or(None),
         event_data: event_str.and_then(|s| serde_json::from_str(&s).ok()),
+        memo: row.get(9).unwrap_or(None),
+        agent_id: row.get(10).unwrap_or(None),
     })
 }
 
@@ -225,6 +280,8 @@ mod tests {
             created_at: 1000,
             expires_at: None,
             event_data: None,
+            memo: None,
+            agent_id: None,
         }
     }
 
@@ -254,6 +311,8 @@ mod tests {
             created_at: 1000,
             expires_at: None,
             event_data: None,
+            memo: None,
+            agent_id: None,
         };
         store.insert(&sub).unwrap();
         let got = store.get("gh-1").unwrap().unwrap();
@@ -335,5 +394,113 @@ mod tests {
         assert_eq!(expired, 0);
         let got = store.get("test-order").unwrap().unwrap();
         assert_eq!(got.status, "fired");
+    }
+
+    #[test]
+    fn test_insert_with_memo_and_agent_id() {
+        let store = Store::open(":memory:").unwrap();
+        let mut sub = timer_sub("agent-sub-1");
+        sub.memo = Some("watch CI for deploy".into());
+        sub.agent_id = Some("agent-abc".into());
+        store.insert(&sub).unwrap();
+        let got = store.get("agent-sub-1").unwrap().unwrap();
+        assert_eq!(got.memo.as_deref(), Some("watch CI for deploy"));
+        assert_eq!(got.agent_id.as_deref(), Some("agent-abc"));
+    }
+
+    #[test]
+    fn test_list_fired_for_agent() {
+        let store = Store::open(":memory:").unwrap();
+
+        // Insert a fired sub with agent_id
+        let mut sub1 = timer_sub("af-1");
+        sub1.agent_id = Some("agent-x".into());
+        sub1.status = "fired".into();
+        store.insert(&sub1).unwrap();
+
+        // Insert an active sub with same agent_id (should NOT appear)
+        let mut sub2 = timer_sub("af-2");
+        sub2.agent_id = Some("agent-x".into());
+        store.insert(&sub2).unwrap();
+
+        // Insert a fired sub with different agent_id (should NOT appear)
+        let mut sub3 = timer_sub("af-3");
+        sub3.agent_id = Some("agent-y".into());
+        sub3.status = "fired".into();
+        store.insert(&sub3).unwrap();
+
+        // Insert a fired sub with no agent_id (should NOT appear)
+        let mut sub4 = timer_sub("af-4");
+        sub4.status = "fired".into();
+        store.insert(&sub4).unwrap();
+
+        let fired = store.list_fired_for_agent("agent-x").unwrap();
+        assert_eq!(fired.len(), 1);
+        assert_eq!(fired[0].id, "af-1");
+    }
+
+    #[test]
+    fn test_mark_dispatched() {
+        let store = Store::open(":memory:").unwrap();
+
+        let mut sub1 = timer_sub("md-1");
+        sub1.agent_id = Some("agent-d".into());
+        sub1.status = "fired".into();
+        store.insert(&sub1).unwrap();
+
+        let mut sub2 = timer_sub("md-2");
+        sub2.agent_id = Some("agent-d".into());
+        sub2.status = "fired".into();
+        store.insert(&sub2).unwrap();
+
+        // Both should appear before dispatch
+        let fired = store.list_fired_for_agent("agent-d").unwrap();
+        assert_eq!(fired.len(), 2);
+
+        // Mark one as dispatched
+        store.mark_dispatched(&["md-1".into()]).unwrap();
+
+        // Only one should remain
+        let fired = store.list_fired_for_agent("agent-d").unwrap();
+        assert_eq!(fired.len(), 1);
+        assert_eq!(fired[0].id, "md-2");
+
+        // Mark the other
+        store.mark_dispatched(&["md-2".into()]).unwrap();
+        let fired = store.list_fired_for_agent("agent-d").unwrap();
+        assert_eq!(fired.len(), 0);
+    }
+
+    #[test]
+    fn test_has_active_subscriptions() {
+        let store = Store::open(":memory:").unwrap();
+
+        // No subscriptions yet
+        assert!(!store.has_active_subscriptions("agent-ha").unwrap());
+
+        // Insert an active sub for the agent
+        let mut sub = timer_sub("ha-1");
+        sub.agent_id = Some("agent-ha".into());
+        store.insert(&sub).unwrap();
+        assert!(store.has_active_subscriptions("agent-ha").unwrap());
+
+        // Different agent should still be false
+        assert!(!store.has_active_subscriptions("agent-other").unwrap());
+
+        // Fire the subscription — should become false
+        store.set_fired("ha-1", &serde_json::json!({})).unwrap();
+        assert!(!store.has_active_subscriptions("agent-ha").unwrap());
+    }
+
+    #[test]
+    fn test_has_active_subscriptions_no_agent_id() {
+        let store = Store::open(":memory:").unwrap();
+
+        // Insert an active sub without agent_id
+        let sub = timer_sub("ha-no-agent");
+        store.insert(&sub).unwrap();
+
+        // Should not match any agent_id query
+        assert!(!store.has_active_subscriptions("agent-z").unwrap());
     }
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -54,6 +54,8 @@ pub struct Subscription {
     pub created_at: i64,    // epoch seconds
     pub expires_at: Option<i64>,
     pub event_data: Option<serde_json::Value>,
+    pub memo: Option<String>,
+    pub agent_id: Option<String>,
 }
 
 impl Subscription {
@@ -61,17 +63,20 @@ impl Subscription {
         let condition = parse_condition(&args.source, &args.args, args.repo.as_deref())?;
         let expires_at = args.timeout.as_deref().map(parse_duration_secs).transpose()?
             .map(|d| Utc::now().timestamp() + d);
+        let mode = if args.detach { "detach" } else { "wait" };
 
         Ok(Self {
             id: uuid::Uuid::new_v4().to_string()[..8].to_string(),
             source: condition.source_name().to_string(),
             condition,
-            mode: "wait".into(),
+            mode: mode.into(),
             callback: None,
             status: "active".into(),
             created_at: Utc::now().timestamp(),
             expires_at,
             event_data: None,
+            memo: args.memo.clone(),
+            agent_id: args.agent_id.clone(),
         })
     }
 
@@ -90,11 +95,13 @@ impl Subscription {
             created_at: Utc::now().timestamp(),
             expires_at,
             event_data: None,
+            memo: None,
+            agent_id: None,
         })
     }
 
     pub fn condition_summary(&self) -> String {
-        match &self.condition {
+        let base = match &self.condition {
             Condition::Timer { duration, .. } => format!("timer {duration}"),
             Condition::GitHub(gh) => match gh {
                 GitHubCondition::PrMerged { repo, number } => format!("{repo} pr #{number} merged"),
@@ -109,7 +116,8 @@ impl Subscription {
                 GitHubCondition::CiFailure { repo, number } => format!("{repo} ci #{number} failure"),
                 GitHubCondition::CiCompleted { repo, number } => format!("{repo} ci #{number} completed"),
             },
-        }
+        };
+        base
     }
 
     #[allow(dead_code)]
@@ -364,6 +372,8 @@ mod tests {
             created_at: 0,
             expires_at: None,
             event_data: None,
+            memo: None,
+            agent_id: None,
         };
         assert_eq!(sub.condition_summary(), "foo/bar pr #42 merged");
 


### PR DESCRIPTION
## Summary

Implements the core of #13 — `nudge agent` for long-lived agent sessions that maintain context across event-driven turns.

- **`nudge agent`**: Runs Claude Code turns via `--resume`, keeping full conversation history as memory
- **`nudge wait --detach --memo`**: Register a subscription and return immediately with a memo for what to do when the event fires
- **Agent loop**: Polls for fired subscriptions, formats events with memos, feeds them as the next turn's prompt
- **`NUDGE_AGENT_ID` env var**: Flows from agent → Claude subprocess → `nudge wait --detach` to associate subscriptions with the owning agent
- **Rate limiting**: Exponential backoff (10s→20s→40s, capped 300s) for consecutive fast turns
- **Idle turns**: Optional `--idle-every` / `--idle-prompt-file` for periodic agent activity
- **Schema migration**: Adds `memo`, `agent_id`, `dispatched_at` columns to subscriptions table

## Follow-up issues

- #14 — Post-turn DB query for immediate event pickup
- #15 — 30/hour turn rate limit

## Test plan

- [x] All 52 unit tests pass
- [ ] Manual: `nudge agent` starts and captures session_id from stream-json
- [ ] Manual: `nudge wait --detach --memo` creates subscription with correct agent_id
- [ ] Manual: Fired subscription triggers a new Claude turn with memo in prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)